### PR TITLE
1.0.0-rc2

### DIFF
--- a/include/mapbox/vector_tile/vector_tile.hpp
+++ b/include/mapbox/vector_tile/vector_tile.hpp
@@ -1,1 +1,1 @@
-#include <vector_tile_config.hpp>
+#include "vector_tile_config.hpp"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "@mapbox/vector-tile",
+    "version": "1.0.0-rc1",
+    "description": "A C++ header only library for decoding and encoding Mapbox Vector Tiles",
+    "main": "./package.json",
+    "repository"   :  {
+      "type" : "git",
+      "url"  : "git://github.com/mapbox/vector-tile.git"
+    }
+}


### PR DESCRIPTION
Getting rc2 ready, which includes:

* a `package.json` to grab headers from other locations
* fixes relative `#include` paths to be `"quotes"` instead of `<brackets>`

cc @springmeyer @GretaCB 