### PR TITLE
Update mvt fixtures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 mason_use(catch VERSION 1.9.6 HEADER_ONLY)
 include_directories(SYSTEM ${MASON_PACKAGE_catch_INCLUDE_DIRS})
 
-mason_use(benchmark VERSION 1.3.0)
+mason_use(benchmark VERSION 1.2.0)
 include_directories(SYSTEM ${MASON_PACKAGE_benchmark_INCLUDE_DIRS})
 
 mason_use(variant VERSION 1.1.5 HEADER_ONLY)

--- a/include/mapbox/vector_tile.hpp
+++ b/include/mapbox/vector_tile.hpp
@@ -74,7 +74,12 @@ layer_map<CoordinateType> decode_tile(std::string const& buffer)
                 fc.push_back(f);
             }
         }
-        m.emplace(std::string(layer.name()), std::move(fc));
+
+        if (!fc.empty())
+        {
+            m.emplace(std::string(layer.name()), std::move(fc));
+        }
+
     }
     return m;
 }

--- a/include/mapbox/vector_tile.hpp
+++ b/include/mapbox/vector_tile.hpp
@@ -79,7 +79,6 @@ layer_map<CoordinateType> decode_tile(std::string const& buffer)
         {
             m.emplace(std::string(layer.name()), std::move(fc));
         }
-
     }
     return m;
 }

--- a/test/unit/decode_fixtures.test.cpp
+++ b/test/unit/decode_fixtures.test.cpp
@@ -18,17 +18,17 @@ static std::string open_tile(std::string const& path)
     return message;
 }
 
-TEST_CASE("Read Feature-single-point.mvt")
+TEST_CASE("Read feature point")
 {
-    std::string buffer = open_tile("test/mvt-fixtures/fixtures/valid/Feature-single-point.mvt");
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/017/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.end() != fm.find("layer_name"));
-    auto fc = fm["layer_name"];
+    REQUIRE(fm.end() != fm.find("hello"));
+    auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
     auto f = fc[0];
     REQUIRE(f.id.is<std::uint64_t>());
-    CHECK(f.id.get<std::uint64_t>() == 123);
+    CHECK(f.id.get<std::uint64_t>() == 1);
     REQUIRE(f.properties.size() == 1);
     REQUIRE(f.properties.end() != f.properties.find("hello"));
     auto val = f.properties["hello"];
@@ -40,17 +40,17 @@ TEST_CASE("Read Feature-single-point.mvt")
     CHECK(pt.y == 17);
 }
 
-TEST_CASE("Read Feature-single-multipoint.mvt")
+TEST_CASE("Read feature multipoint")
 {
-    std::string buffer = open_tile("test/mvt-fixtures/fixtures/valid/Feature-single-multipoint.mvt");
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/020/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.end() != fm.find("layer_name"));
-    auto fc = fm["layer_name"];
+    REQUIRE(fm.end() != fm.find("hello"));
+    auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
     auto f = fc[0];
     REQUIRE(f.id.is<std::uint64_t>());
-    CHECK(f.id.get<std::uint64_t>() == 123);
+    CHECK(f.id.get<std::uint64_t>() == 1);
     REQUIRE(f.properties.size() == 1);
     REQUIRE(f.properties.end() != f.properties.find("hello"));
     auto val = f.properties["hello"];
@@ -65,18 +65,18 @@ TEST_CASE("Read Feature-single-multipoint.mvt")
     CHECK(mp[1].y == 2);
 }
 
-TEST_CASE("Read Feature-single-linestring.mvt")
+TEST_CASE("Read feature linestring")
 {
-    std::string buffer = open_tile("test/mvt-fixtures/fixtures/valid/Feature-single-linestring.mvt");
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/018/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.end() != fm.find("layer_name"));
-    auto fc = fm["layer_name"];
+    REQUIRE(fm.end() != fm.find("hello"));
+    auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
     auto f = fc[0];
     REQUIRE(f.id.is<std::uint64_t>());
-    CHECK(f.id.get<std::uint64_t>() == 123);
+    CHECK(f.id.get<std::uint64_t>() == 1);
     REQUIRE(f.properties.size() == 1);
     REQUIRE(f.properties.end() != f.properties.find("hello"));
     auto val = f.properties["hello"];
@@ -93,18 +93,18 @@ TEST_CASE("Read Feature-single-linestring.mvt")
     CHECK(ls[2].y == 10);
 }
 
-TEST_CASE("Read Feature-single-multilinestring.mvt")
+TEST_CASE("Read feature multilinestring")
 {
-    std::string buffer = open_tile("test/mvt-fixtures/fixtures/valid/Feature-single-multilinestring.mvt");
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/021/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.end() != fm.find("layer_name"));
-    auto fc = fm["layer_name"];
+    REQUIRE(fm.end() != fm.find("hello"));
+    auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
     auto f = fc[0];
     REQUIRE(f.id.is<std::uint64_t>());
-    CHECK(f.id.get<std::uint64_t>() == 123);
+    CHECK(f.id.get<std::uint64_t>() == 1);
     REQUIRE(f.properties.size() == 1);
     REQUIRE(f.properties.end() != f.properties.find("hello"));
     auto val = f.properties["hello"];
@@ -127,18 +127,18 @@ TEST_CASE("Read Feature-single-multilinestring.mvt")
     CHECK(mls[1][1].y == 5);
 }
 
-TEST_CASE("Read Feature-single-polygon.mvt")
+TEST_CASE("Read feature polygon")
 {
-    std::string buffer = open_tile("test/mvt-fixtures/fixtures/valid/Feature-single-polygon.mvt");
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/019/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.end() != fm.find("layer_name"));
-    auto fc = fm["layer_name"];
+    REQUIRE(fm.end() != fm.find("hello"));
+    auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
     auto f = fc[0];
     REQUIRE(f.id.is<std::uint64_t>());
-    CHECK(f.id.get<std::uint64_t>() == 123);
+    CHECK(f.id.get<std::uint64_t>() == 1);
     REQUIRE(f.properties.size() == 1);
     REQUIRE(f.properties.end() != f.properties.find("hello"));
     auto val = f.properties["hello"];
@@ -156,18 +156,17 @@ TEST_CASE("Read Feature-single-polygon.mvt")
     CHECK(poly[0][2].y == 34);
 }
 
-/*
-TEST_CASE( "Read Feature-single-multipolygon.mvt" ) {
-    std::string buffer = open_tile("test/mvt-fixtures/fixtures/valid/Feature-single-multipolygon.mvt");
+TEST_CASE( "Read feature multipolygon" ) {
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/022/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.end() != fm.find("layer_name"));
-    auto fc = fm["layer_name"];
+    REQUIRE(fm.end() != fm.find("hello"));
+    auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
     auto f = fc[0];
     REQUIRE(f.id.is<std::uint64_t>());
-    CHECK(f.id.get<std::uint64_t>() == 123);
+    CHECK(f.id.get<std::uint64_t>() == 1);
     REQUIRE(f.properties.size() == 1);
     REQUIRE(f.properties.end() != f.properties.find("hello"));
     auto val = f.properties["hello"];
@@ -183,4 +182,4 @@ TEST_CASE( "Read Feature-single-multipolygon.mvt" ) {
     CHECK(mpoly[0][0][1].y == 12);
     CHECK(mpoly[0][0][2].x == 20);
     CHECK(mpoly[0][0][2].y == 34);
-}*/
+}

--- a/test/unit/decode_fixtures.test.cpp
+++ b/test/unit/decode_fixtures.test.cpp
@@ -175,11 +175,16 @@ TEST_CASE( "Read feature multipolygon" ) {
     REQUIRE(f.geometry.is<mapbox::geometry::multi_polygon<std::int64_t>>());
     auto mpoly = f.geometry.get<mapbox::geometry::multi_polygon<std::int64_t>>();
     REQUIRE(mpoly.size() == 2);
-    REQUIRE(mpoly[0].size() == 4);
-    CHECK(mpoly[0][0][0].x == 3);
-    CHECK(mpoly[0][0][0].y == 6);
-    CHECK(mpoly[0][0][1].x == 8);
-    CHECK(mpoly[0][0][1].y == 12);
-    CHECK(mpoly[0][0][2].x == 20);
-    CHECK(mpoly[0][0][2].y == 34);
+    REQUIRE(mpoly[0].size() == 1);
+    REQUIRE(mpoly[0][0].size() == 5);
+    CHECK(mpoly[0][0][0].x == 0);
+    CHECK(mpoly[0][0][0].y == 0);
+    CHECK(mpoly[0][0][1].x == 10);
+    CHECK(mpoly[0][0][1].y == 0);
+    CHECK(mpoly[0][0][2].x == 10);
+    CHECK(mpoly[0][0][2].y == 10);
+    CHECK(mpoly[0][0][3].x == 0);
+    CHECK(mpoly[0][0][3].y == 10);
+    CHECK(mpoly[0][0][4].x == 0);
+    CHECK(mpoly[0][0][4].y == 0);
 }

--- a/test/unit/decode_fixtures.test.cpp
+++ b/test/unit/decode_fixtures.test.cpp
@@ -70,7 +70,6 @@ TEST_CASE("Read feature linestring")
     std::string buffer = open_tile("test/mvt-fixtures/fixtures/018/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.size() == 1);
     REQUIRE(fm.end() != fm.find("hello"));
     auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
@@ -97,7 +96,6 @@ TEST_CASE("Read feature multilinestring")
 {
     std::string buffer = open_tile("test/mvt-fixtures/fixtures/021/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
-    REQUIRE(fm.size() == 1);
     REQUIRE(fm.size() == 1);
     REQUIRE(fm.end() != fm.find("hello"));
     auto fc = fm["hello"];
@@ -132,7 +130,6 @@ TEST_CASE("Read feature polygon")
     std::string buffer = open_tile("test/mvt-fixtures/fixtures/019/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
     REQUIRE(fm.size() == 1);
-    REQUIRE(fm.size() == 1);
     REQUIRE(fm.end() != fm.find("hello"));
     auto fc = fm["hello"];
     REQUIRE(fc.size() == 1);
@@ -156,10 +153,10 @@ TEST_CASE("Read feature polygon")
     CHECK(poly[0][2].y == 34);
 }
 
-TEST_CASE( "Read feature multipolygon" ) {
+TEST_CASE("Read feature multipolygon")
+{
     std::string buffer = open_tile("test/mvt-fixtures/fixtures/022/tile.mvt");
     auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
-    REQUIRE(fm.size() == 1);
     REQUIRE(fm.size() == 1);
     REQUIRE(fm.end() != fm.find("hello"));
     auto fc = fm["hello"];
@@ -187,4 +184,11 @@ TEST_CASE( "Read feature multipolygon" ) {
     CHECK(mpoly[0][0][3].y == 10);
     CHECK(mpoly[0][0][4].x == 0);
     CHECK(mpoly[0][0][4].y == 0);
+}
+
+TEST_CASE("Read invalid: missing geometry type field")
+{
+    std::string buffer = open_tile("test/mvt-fixtures/fixtures/003/tile.mvt");
+    auto fm = mapbox::vector_tile::decode_tile<std::int64_t>(buffer);
+    CHECK(fm.empty());
 }


### PR DESCRIPTION
This updates mvt-fixtures to the latest 3.x system and updates unit tests accordingly, plus we now have a multipolygon test!

This also reverts google benchmark to 1.2.0 since 1.3.0 conflicts with macos Sierra currently - feels like a system error rather than benchmark. I'll report back on getting it fixed.

@flippmoke @GretaCB 