### PR TITLE
Remove mvt-bench-fixtures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tests/mvt-fixtures"]
 	path = test/mvt-fixtures
 	url = https://github.com/mapbox/mvt-fixtures.git
-[submodule "bench/mvt-bench-fixtures"]
-	path = bench/mvt-bench-fixtures
-	url = https://github.com/mapbox/mvt-bench-fixtures.git


### PR DESCRIPTION
Per https://github.com/mapbox/vector-tile/pull/25, consolidating use of mvt-fixtures to one location and one fixtures repo. 

cc @mapsam @flippmoke 