### PR TITLE
Preventing Overflows and Underflows on Points

### DIFF
--- a/include/mapbox/vector_tile.hpp
+++ b/include/mapbox/vector_tile.hpp
@@ -224,8 +224,8 @@ template <typename GeometryCollectionType>
 GeometryCollectionType feature::getGeometries(float scale) const {
     std::uint8_t cmd = 1;
     std::uint32_t length = 0;
-    std::int32_t x = 0;
-    std::int32_t y = 0;
+    std::int64_t x = 0;
+    std::int64_t y = 0;
 
     GeometryCollectionType paths;
 


### PR DESCRIPTION
It is currently possible to have an overflow or underflow in our x or y position if multiple int32_t deltas push a value outside of the max range of an int32_t. This change bumps the x and y values to int64_t. It is still possible to have an overflow or underflow, however, this is much less likely and would require a large number of large deltas to reach this point.

/cc @kkaefer @springmeyer 