### PR TITLE
Fix compilation errors with libc++ on QNX 7

### DIFF
--- a/include/mapbox/vector_tile.hpp
+++ b/include/mapbox/vector_tile.hpp
@@ -23,13 +23,15 @@ using point_type = mapbox::geometry::point<std::int16_t>;
 class points_array_type : public std::vector<point_type> {
 public:
     using coordinate_type = point_type::coordinate_type;
-    using std::vector<point_type>::vector;
+    template <class... Args>
+    points_array_type(Args&&... args) : std::vector<point_type>(std::forward<Args>(args)...) {}
 };
 
 class points_arrays_type : public std::vector<points_array_type> {
 public:
     using coordinate_type = points_array_type::coordinate_type;
-    using std::vector<points_array_type>::vector;
+    template <class... Args>
+    points_arrays_type(Args&&... args) : std::vector<points_array_type>(std::forward<Args>(args)...) {}
 };
 
 class layer;
@@ -137,7 +139,7 @@ inline feature::feature(protozero::data_view const& feature_view, layer const& l
     while (feature_pbf.next()) {
         switch (feature_pbf.tag()) {
         case FeatureType::ID:
-            id = { feature_pbf.get_uint64() };
+            id = optional<mapbox::geometry::identifier>{ feature_pbf.get_uint64() };
             break;
         case FeatureType::TAGS:
             tags_iter = feature_pbf.get_packed_uint32();


### PR DESCRIPTION
Fix build errors on QNX 7 compiler (i.e qcc based GCC 5.4.0 with libc++ from LLVM).

Build erros:
```
error: ambiguous overload for 'operator=' (operand types are 'optional<mapbox::util::variant<long unsigned int, long int, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > {aka std::experimental::fundamentals_v1::optional<mapbox::util::variant<long unsigned int, long int, double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >}' and '<brace-enclosed initializer list>')
             id = { feature_pbf.get_uint64() };
                ^

mapbox-gl-native/deps/vector-tile/1.0.1/include/mapbox/vector_tile.hpp:28:32: error: 'template<class _InputIterator> mapbox::vector_tile::points_array_type::points_array_type(_InputIterator, _InputIterator, const allocator_type&)' inherited from 'std::__1::vector<mapbox::geometry::point<short int> >'
 using std::vector<point_type>::vector;
                                ^
mapbox-gl-native/deps/vector-tile/1.0.1/include/mapbox/vector_tile.hpp:28:32: error: conflicts with version inherited from 'std::__1::vector<mapbox::geometry::point<short int> >'
```