### PR TITLE
Support for geometry v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DEMO_DIR:=./demo
 
 export BUILDTYPE ?= Release
 
-export GEOMETRY_RELEASE ?= 0.9.0
+export GEOMETRY_RELEASE ?= 1.0.0
 export PROTOZERO_RELEASE ?= 1.5.1
 export VARIANT_RELEASE ?= 1.1.4
 
@@ -28,7 +28,7 @@ HEADERS = $(wildcard include/mapbox/vector_tile/*.hpp) include/mapbox/vector_til
 
 ./.mason/mason:
 	mkdir ./.mason
-	curl -sSfL https://github.com/mapbox/mason/archive/v0.8.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./.mason
+	curl -sSfL https://github.com/mapbox/mason/archive/v0.19.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./.mason
 
 mason_packages/headers/protozero: .mason/mason
 	.mason/mason install protozero $(PROTOZERO_RELEASE) && .mason/mason link protozero $(PROTOZERO_RELEASE)

--- a/bench/run.cpp
+++ b/bench/run.cpp
@@ -17,7 +17,7 @@ static void decode_entire_tile(std::string const& buffer) {
         for (std::size_t i=0;i<num_features;++i) {
             auto const feature = mapbox::vector_tile::feature(layer.getFeature(i),layer);
             auto const& feature_id = feature.getID();
-            if (!feature_id) {
+            if (feature_id.is<mapbox::feature::null_value_t>()) {
                 throw std::runtime_error("Hit unexpected error decoding feature");
             }
             auto props = feature.getProperties();

--- a/demo/decode.cpp
+++ b/demo/decode.cpp
@@ -17,15 +17,15 @@ std::string open_tile(std::string const& path) {
 class print_value {
 
 public:
-    std::string operator()(std::vector<mapbox::geometry::value> val) {
+    std::string operator()(std::vector<mapbox::feature::value> val) {
         return "vector";
     }
 
-    std::string operator()(std::unordered_map<std::string, mapbox::geometry::value> val) {
+    std::string operator()(std::unordered_map<std::string, mapbox::feature::value> val) {
         return "unordered_map";
     }
 
-    std::string operator()(mapbox::geometry::null_value_t val) {
+    std::string operator()(mapbox::feature::null_value_t val) {
         return "null";
     }
 
@@ -73,8 +73,8 @@ int main(int argc, char** argv) {
             for (std::size_t i=0;i<feature_count;++i) {
                 auto const feature = mapbox::vector_tile::feature(layer.getFeature(i),layer);
                 auto const& feature_id = feature.getID();
-                if (feature_id) {
-                    std::cout << "    id: " << (*feature_id).get<uint64_t>() << "\n";
+                if (feature_id.is<uint64_t>()) {
+                    std::cout << "    id: " << feature_id.get<uint64_t>() << "\n";
                 } else {
                     std::cout << "    id: (no id set)\n";
                 }
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
                     std::string value = mapbox::util::apply_visitor(printvisitor, prop.second);
                     std::cout << "      " << prop.first  << ": " << value << "\n";
                 }
-                std::cout << "    Verticies:\n";
+                std::cout << "    Vertices:\n";
                 mapbox::vector_tile::points_arrays_type geom = feature.getGeometries<mapbox::vector_tile::points_arrays_type>(1.0);
                 for (auto const& point_array : geom) {
                     for (auto const& point : point_array) {

--- a/test/unit/vector_tile.test.cpp
+++ b/test/unit/vector_tile.test.cpp
@@ -26,9 +26,8 @@ static std::string open_tile(std::string const& path) {
     REQUIRE(layer.getName() == "layer_name"); \
     auto const feature = mapbox::vector_tile::feature(layer.getFeature(0),layer); \
     auto const& feature_id = feature.getID(); \
-    REQUIRE(feature_id); \
-    REQUIRE((*feature_id).is<uint64_t>()); \
-    REQUIRE((*feature_id).get<uint64_t>() == 123ull); \
+    REQUIRE(feature_id.is<uint64_t>()); \
+    REQUIRE(feature_id.get<uint64_t>() == 123ull); \
     auto props = feature.getProperties(); \
     auto itr = props.find("hello"); \
     REQUIRE(itr != props.end()); \
@@ -36,9 +35,8 @@ static std::string open_tile(std::string const& path) {
     REQUIRE(val.is<std::string>()); \
     REQUIRE(val.get<std::string>() == "world"); \
     auto opt_val = feature.getValue("hello"); \
-    REQUIRE(opt_val); \
-    REQUIRE(opt_val->is<std::string>()); \
-    REQUIRE(opt_val->get<std::string>() == "world"); \
+    REQUIRE(opt_val.is<std::string>()); \
+    REQUIRE(opt_val.get<std::string>() == "world"); \
     mapbox::vector_tile::points_arrays_type geom = feature.getGeometries<mapbox::vector_tile::points_arrays_type>(1.0);
 
 std::string stringify_geom(mapbox::vector_tile::points_arrays_type const& geom) {


### PR DESCRIPTION
Update the public interface for geometry.hpp v1.0.0 release, which includes:
- Removal of `optional` dependency
- Separation between `mapbox::feature` and `mapbox::geometry`